### PR TITLE
Handle error for missing localStorage

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -59,7 +59,11 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
     const enable = disableTransitionOnChange ? disableAnimation() : null
 
     if (updateStorage) {
-      localStorage.setItem(storageKey, theme)
+      try {
+        localStorage.setItem(storageKey, theme)
+      } catch (e) {
+        // Unsupported
+      }
     }
 
     const d = document.documentElement
@@ -243,7 +247,7 @@ const getTheme = (key: string) => {
   let theme
   try {
     theme = localStorage.getItem(key) || undefined
-  } catch(e) {
+  } catch (e) {
     // Unsupported
   }
   return theme

--- a/index.tsx
+++ b/index.tsx
@@ -240,7 +240,13 @@ const ThemeScript = memo(
 // Helpers
 const getTheme = (key: string) => {
   if (typeof window === 'undefined') return undefined
-  return localStorage.getItem(key) || undefined
+  let theme
+  try {
+    theme = localStorage.getItem(key) || undefined
+  } catch(e) {
+    // Unsupported
+  }
+  return theme
 }
 
 const disableAnimation = () => {


### PR DESCRIPTION
Recently started using the package in a Next project to replace a custom solution - thanks for making it!

Have seen some errors coming through in Sentry relating to `localStorage.getItem()`

```
TypeError
Cannot read property 'getItem' of null
```

I guess when people have certain security settings, use incognito mode or have a very old browser?

It seems like the `<NextHead>` scripts added via `dangerouslySetInnerHTML` already error-trap their `localStorage` calls, but not elsewhere?

Added a `try/catch` block inside the `getTheme()` function in this PR to handle unsupported browsers.

**Edit:**

Just updated the `<ThemeProvider>` render method, adding a `try/catch`  there too for `localStorage.setItem()`