### PR TITLE
Update peerDependencies to avoid incorrect warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "dependencies": {},
   "peerDependencies": {
     "next": "^9.5.5",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",


### PR DESCRIPTION
This package works with React 17, so updating peerDependencies to avoid incorrect warning during `npm install` or `yarn install`.