### PR TITLE
custom theme names instead of "light" + "dark"

### DIFF
--- a/examples/example/package.json
+++ b/examples/example/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "next": "^9.5.5",
-    "next-themes": "../dist",
+    "next-themes": "../../dist",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   }

--- a/examples/example/pages/_app.js
+++ b/examples/example/pages/_app.js
@@ -1,12 +1,16 @@
-import { ThemeProvider } from 'next-themes'
-import '../styles.css'
+import { ThemeProvider } from "next-themes";
+import "../styles.css";
 
 function MyApp({ Component, pageProps }) {
   return (
-    <ThemeProvider forcedTheme={Component.theme || undefined}>
+    <ThemeProvider
+      forcedTheme={Component.theme || undefined}
+      attribute="class"
+      themes={["my-light-theme", "my-dark-theme"]}
+    >
       <Component {...pageProps} />
     </ThemeProvider>
-  )
+  );
 }
 
-export default MyApp
+export default MyApp;

--- a/examples/example/pages/dark.js
+++ b/examples/example/pages/dark.js
@@ -8,5 +8,5 @@ const Page = () => {
   )
 }
 
-Page.theme = 'dark'
+Page.theme = 'my-dark-theme'
 export default Page

--- a/examples/example/pages/index.js
+++ b/examples/example/pages/index.js
@@ -1,17 +1,21 @@
-import { useTheme } from 'next-themes'
-import Link from 'next/link'
+import { useTheme } from "next-themes";
+import Link from "next/link";
 
 const Index = () => {
-  const { theme, setTheme } = useTheme()
+  const { theme, themes, setTheme } = useTheme();
 
   return (
     <div>
       <h1>next-themes Example</h1>
       {theme !== undefined && (
         <select value={theme} onChange={(e) => setTheme(e.target.value)}>
-          <option value="dark">Dark</option>
-          <option value="light">Light</option>
-          <option value="system">System</option>
+          {themes.map((theme) => {
+            return (
+              <option key={theme} value={theme}>
+                {theme}
+              </option>
+            );
+          })}
         </select>
       )}
 
@@ -21,16 +25,14 @@ const Index = () => {
       <div>
         <Link href="/dark">
           <a>Forced Dark Page</a>
-        </Link>
-
-        {' '}•{' '}
-
+        </Link>{" "}
+        •{" "}
         <Link href="/light">
           <a>Forced Light Page</a>
         </Link>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default Index
+export default Index;

--- a/examples/example/pages/light.js
+++ b/examples/example/pages/light.js
@@ -8,5 +8,5 @@ const Page = () => {
 	)
 }
 
-Page.theme = 'light'
+Page.theme = 'my-light-theme'
 export default Page

--- a/examples/example/styles.css
+++ b/examples/example/styles.css
@@ -7,7 +7,7 @@
   --bg: #fff;
 }
 
-[data-theme="dark"] {
+.my-dark-theme {
   --fg: #fff;
   --bg: #000;
 }

--- a/examples/example/yarn.lock
+++ b/examples/example/yarn.lock
@@ -3412,7 +3412,7 @@ neo-async@^2.5.0, neo-async@^2.6.1, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next-themes@../dist:
+next-themes@../../dist:
   version "0.0.0"
 
 next-tick@~1.0.0:

--- a/index.tsx
+++ b/index.tsx
@@ -23,8 +23,6 @@ const ThemeContext = createContext<UseThemeProps>({
 })
 export const useTheme = () => useContext(ThemeContext)
 
-const colorSchemes = ['light', 'dark']
-
 interface ValueObject {
   [themeName: string]: string
 }
@@ -36,6 +34,7 @@ export interface ThemeProviderProps {
   enableColorScheme?: boolean
   storageKey?: string
   themes?: string[]
+  colorSchemes?: string[]
   defaultTheme?: string
   attribute?: string
   value?: ValueObject
@@ -48,6 +47,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   enableColorScheme = true,
   storageKey = 'theme',
   themes = ['light', 'dark'],
+  colorSchemes = themes,
   defaultTheme = enableSystem ? 'system' : 'light',
   attribute = 'data-theme',
   value,
@@ -92,7 +92,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   const handleMediaQuery = useCallback(
     (e) => {
       const isDark = e.matches
-      const systemTheme = isDark ? 'dark' : 'light'
+      const systemTheme = isDark ? colorSchemes[1] || 'dark' : colorSchemes[0] || 'light'
       setResolvedTheme(systemTheme)
 
       if (theme === 'system' && !forcedTheme) changeTheme(systemTheme, false)
@@ -249,7 +249,7 @@ const ThemeScript = memo(
             key="next-themes-script"
             dangerouslySetInnerHTML={{
               // prettier-ignore
-              __html: `!function(){try {${optimization}var e=localStorage.getItem('${storageKey}');${!defaultSystem ? updateDOM(defaultTheme) + ';' : ''}if("system"===e||(!e&&${defaultSystem})){var t="(prefers-color-scheme: dark)",m=window.matchMedia(t);m.media!==t||m.matches?${updateDOM('dark')}:${updateDOM('light')}}else if(e) ${value ? `var x=${JSON.stringify(value)};` : ''}${updateDOM(value ? 'x[e]' : 'e', true)}}catch(e){}}()`
+              __html: `!function(){try {${optimization}var e=localStorage.getItem('${storageKey}');${!defaultSystem ? updateDOM(defaultTheme) + ';' : ''}if("system"===e||(!e&&${defaultSystem})){var t="(prefers-color-scheme: dark)",m=window.matchMedia(t);m.media!==t||m.matches?${updateDOM(attrs[1] || 'dark')}:${updateDOM(attrs[0] || 'light')}}else if(e) ${value ? `var x=${JSON.stringify(value)};` : ''}${updateDOM(value ? 'x[e]' : 'e', true)}}catch(e){}}()`
             }}
           />
         ) : (

--- a/index.tsx
+++ b/index.tsx
@@ -95,7 +95,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
       const systemTheme = isDark ? colorSchemes[1] || 'dark' : colorSchemes[0] || 'light'
       setResolvedTheme(systemTheme)
 
-      if (theme === 'system' && !forcedTheme) changeTheme(systemTheme, false)
+      if (theme === 'system' && !forcedTheme) changeTheme(systemTheme)
     },
     [theme, forcedTheme]
   )


### PR DESCRIPTION
I ran into a use-case where I wanted:

1) use `attribute="class"` in the `ThemeProvider`
2) enable "system" defaulting to darkmode on devices that match that media query
3) be able to use custom CSS classnames (not just `light` and `dark`)

The reason for this is because the theme classnames are autogenerated (I'm using [stitches.js](stitches.dev)) - but I'm sure there are many other reasons why people would want the above 3 points

I've tested this locally and it seems to work pretty well. Maybe the implementation could be improved?

Let me know if you have any thoughts / questions!
