### PR TITLE
Improve readme and link to GitHub repository on NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# next-themes ![next-themes minzip package size](https://img.shields.io/bundlephobia/minzip/next-themes)
+# next-themes ![next-themes minzip package size](https://img.shields.io/bundlephobia/minzip/next-themes) ![Version](https://img.shields.io/npm/v/next-themes.svg?colorB=green)
 
 An abstraction for themes in your Next.js app.
 

--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
     "@types/react": "^16.9.53",
     "microbundle": "^0.12.3",
     "typescript": "^4.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pacocoursey/next-themes.git"
   }
 }


### PR DESCRIPTION
## Why I opened this repo
While working on #12 I noticed that some information are not visible here on GitHub and also on NPM.
For example on the NPM page I would expect to see the repository-url and on here expect to see the latest version of the package. In order to add this info I created this PR.

## This PR aims to:
- add version badge to readme that shows the version number of the package published on npm
- add link to the GitHub repository, so that on NPM the repository is listed