### PR TITLE
Use default theme if localstorage value deleted manually 

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -140,8 +140,8 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
       if (e.key !== storageKey) {
         return
       }
-
-      const theme = e.newValue
+      // If default theme set, use it if localstorage === null (happens on local storage manual deletion)
+      const theme = e.newValue || defaultTheme
       setTheme(theme)
     }
 


### PR DESCRIPTION
Hey thanks for the project 😃

When you (or a user) deletes the localStorage value manually via dev tools or otherwise, the value is set as `null` and no themes are used. 

Example:

![null being set](https://user-images.githubusercontent.com/532272/120081500-d9558f80-c072-11eb-8b48-3690cf628b1f.gif)

It seems like this should revert to defaultValue if it's set in the provider and never be set to null.




