### PR TITLE
Update readme with `next/image` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ For example, with [`next/image`](https://nextjs.org/docs/basic-features/image-op
 import Image from 'next/image'
 import { useTheme } from 'next-themes'
 
+function ThemedImage() {
 const { resolvedTheme } = useTheme()
 let src
 
@@ -356,6 +357,7 @@ switch (resolvedTheme) {
 }
 
 <Image src={src} width={400} height={400} />
+}
 ```
 
 ### With Tailwind

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ const ThemeChanger = () => {
 
 To avoid [Layout Shift](https://web.dev/cls/), consider rendering a skeleton/placeholder until mounted on the client side.
 
-For example, with [`next/image`](https://nextjs.org/docs/basic-features/image-optimization) you can use an empty image until the them is resolved.
+For example, with [`next/image`](https://nextjs.org/docs/basic-features/image-optimization) you can use an empty image until the theme is resolved.
 
 ```js
 import Image from 'next/image'

--- a/README.md
+++ b/README.md
@@ -332,7 +332,31 @@ const ThemeChanger = () => {
 }
 ```
 
-To avoid Content Layout Shift, consider rendering a skeleton until mounted on the client side.
+To avoid [Layout Shift](https://web.dev/cls/), consider rendering a skeleton/placeholder until mounted on the client side.
+
+For example, with [`next/image`](https://nextjs.org/docs/basic-features/image-optimization) you can use an empty image until the them is resolved.
+
+```js
+import Image from 'next/image'
+import { useTheme } from 'next-themes'
+
+const { resolvedTheme } = useTheme()
+let src
+
+switch (resolvedTheme) {
+  case 'light':
+    src = '/light.png'
+    break
+  case 'dark':
+    src = '/dark.png'
+    break
+  default:
+    src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+    break
+}
+
+<Image src={src} width={400} height={400} />
+```
 
 ### With Tailwind
 

--- a/README.md
+++ b/README.md
@@ -341,22 +341,22 @@ import Image from 'next/image'
 import { useTheme } from 'next-themes'
 
 function ThemedImage() {
-const { resolvedTheme } = useTheme()
-let src
+  const { resolvedTheme } = useTheme()
+  let src
 
-switch (resolvedTheme) {
-  case 'light':
-    src = '/light.png'
-    break
-  case 'dark':
-    src = '/dark.png'
-    break
-  default:
-    src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
-    break
-}
+  switch (resolvedTheme) {
+    case 'light':
+      src = '/light.png'
+      break
+    case 'dark':
+      src = '/dark.png'
+      break
+    default:
+      src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+      break
+  }
 
-<Image src={src} width={400} height={400} />
+  return <Image src={src} width={400} height={400} />
 }
 ```
 


### PR DESCRIPTION
This example will avoid layout shift because the `width`/`height` remain the same – only the `src` is swapped.

Additionally we add a transparent gif placeholder until we can determine if the theme is dark or light.