### PR TITLE
Return the final-theme value for a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ useTheme takes no parameters, but returns:
 - `resolvedTheme`: If `enableSystem` is true and the active theme is "system", this returns whether the system preference resolved to "dark" or "light". Otherwise, identical to `theme`
 - `systemTheme`: If `enableSystem` is true, represents the System theme preference ("dark" or "light"), regardless what the active theme is
 - `themes`: The list of themes passed to `ThemeProvider` (with "system" appended, if `enableSystem` is true)
+- `finalTheme`: Returns `forcedTheme` if set. Otherwise, the `resolvedTheme` is returned.
 
 Not too bad, right? Let's see how to use these properties with examples:
 

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -6,7 +6,7 @@ let localStorageMock: { [key: string]: string } = {}
 
 // HelperComponent to render the theme inside a paragraph-tag and setting a theme via the forceSetTheme prop
 const HelperComponent = ({ forceSetTheme }: { forceSetTheme?: string }) => {
-  const { setTheme, theme, forcedTheme } = useTheme()
+  const { setTheme, theme, forcedTheme, resolvedTheme, finalTheme } = useTheme()
 
   useEffect(() => {
     if (forceSetTheme) {
@@ -18,6 +18,8 @@ const HelperComponent = ({ forceSetTheme }: { forceSetTheme?: string }) => {
     <>
       <p data-testid="theme">{theme}</p>
       <p data-testid="forcedTheme">{forcedTheme}</p>
+      <p data-testid="resolvedTheme">{resolvedTheme}</p>
+      <p data-testid="finalTheme">{finalTheme}</p>
     </>
   )
 }
@@ -219,5 +221,37 @@ describe('forcedTheme test-suite', () => {
 
     expect(screen.getByTestId('theme').textContent).toBe('dark')
     expect(screen.getByTestId('forcedTheme').textContent).toBe('light')
+  })
+})
+
+describe('finalTheme test-suite', () => {
+  test('should return resolved theme if no theme is forced', () => {
+    localStorageMock['theme'] = 'dark'
+
+    act(() => {
+      render(
+        <ThemeProvider>
+          <HelperComponent />
+        </ThemeProvider>
+      )
+    })
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark')
+    expect(screen.getByTestId('finalTheme').textContent).toBe('dark')
+  })
+
+  test('should return froced-theme as final-theme', () => {
+    localStorageMock['theme'] = 'dark'
+
+    act(() => {
+      render(
+        <ThemeProvider forcedTheme='light'>
+          <HelperComponent />
+        </ThemeProvider>
+      )
+    })
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark')
+    expect(screen.getByTestId('finalTheme').textContent).toBe('light')
   })
 })

--- a/index.tsx
+++ b/index.tsx
@@ -22,6 +22,8 @@ export interface UseThemeProps {
   resolvedTheme?: string
   /** If enableSystem is true, returns the System theme preference ("dark" or "light"), regardless what the active theme is */
   systemTheme?: 'dark' | 'light'
+  /** Final theme of the page, either the forced-theme, if defined, or the resovled-theme  */
+  finalTheme?: string
 }
 
 export interface ThemeProviderProps {
@@ -74,6 +76,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
     getTheme(storageKey, defaultTheme)
   )
   const [resolvedTheme, setResolvedTheme] = useState(() => getTheme(storageKey))
+  const userResolvedTheme = theme === 'system' ? resolvedTheme : theme
   const attrs = !value ? themes : Object.values(value)
 
   const handleMediaQuery = useCallback(
@@ -184,14 +187,16 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
     // if color-scheme is null, this will remove the property
     document.documentElement.style.setProperty('color-scheme', colorScheme)
   }, [enableColorScheme, theme, resolvedTheme, forcedTheme])
-
+  
+  
   return (
     <ThemeContext.Provider
       value={{
         theme,
         setTheme,
         forcedTheme,
-        resolvedTheme: theme === 'system' ? resolvedTheme : theme,
+        resolvedTheme: userResolvedTheme,
+        finalTheme: forcedTheme ?? userResolvedTheme,
         themes: enableSystem ? [...themes, 'system'] : themes,
         systemTheme: (enableSystem ? resolvedTheme : undefined) as
           | 'light'


### PR DESCRIPTION
Adds a new `final-theme` value to the theme-context. (Closes #70)
The new value is equal to the `forced-theme`, if one is defined.
Otherwise it is set equal to the resolved theme.
