### PR TITLE
Fix `d.style` being undefined and code golf

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -184,11 +184,11 @@ const ThemeScript = memo(
     // Code-golfing the amount of characters in the script
     const optimization = (() => {
       if (attribute === 'class') {
-        const removeClasses = `d.remove(${attrs.map((t: string) => `'${t}'`).join(',')})`
+        const removeClasses = `c.remove(${attrs.map((t: string) => `'${t}'`).join(',')})`
 
-        return `var d=document.documentElement.classList;${removeClasses};`
+        return `var d=document.documentElement,c=d.classList;${removeClasses};`
       } else {
-        return `var d=document.documentElement;var n='${attribute}';var s = 'setAttribute';`
+        return `var d=document.documentElement,n='${attribute}',s='setAttribute';`
       }
     })()
 
@@ -220,13 +220,13 @@ const ThemeScript = memo(
 
       if (attribute === 'class') {
         if (literal || resolvedName) {
-          text += `d.add(${val})`
+          text += `c.add(${val})`
         } else {
           text += `null`
         }
       } else {
         if (resolvedName) {
-          text += `d[s](n, ${val})`
+          text += `d[s](n,${val})`
         }
       }
 
@@ -239,7 +239,7 @@ const ThemeScript = memo(
       }
 
       if (enableSystem) {
-        return `!function(){try {${optimization}var e=localStorage.getItem('${storageKey}');if("system"===e||(!e&&${defaultSystem})){var t="${MEDIA}",m=window.matchMedia(t);if(m.media!==t||m.matches){${updateDOM(
+        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if("system"===e||(!e&&${defaultSystem})){var t="${MEDIA}",m=window.matchMedia(t);if(m.media!==t||m.matches){${updateDOM(
           'dark'
         )}}else{${updateDOM('light')}}}else if(e){${
           value ? `var x=${JSON.stringify(value)};` : ''


### PR DESCRIPTION
When using `attribute: 'class'`, the inserted script tag will be:

```html
<script>
!function(){try {
  var d=document.documentElement.classList;
  d.remove('light','dark');
  var e=localStorage.getItem('theme');
  if("system"===e||(!e&&true)){
    var t="(prefers-color-scheme: dark)",m=window.matchMedia(t);
    if(m.media!==t||m.matches){
      d.style.colorScheme = 'dark';
      d.add('dark')
    }else{
      d.style.colorScheme = 'light';
      d.add('light')}
    }else if(e){
      d.add(e|| '')
    }
    if(e==='light'||e==='dark')
      d.style.colorScheme=e
  }catch(e){}
}()
</script>
```

...where `d=document.documentElement.classList` but later it tries to access its `style` property via `d.style.colorScheme`. Should be using `document.documentElement` here instead.

This PR changes it to explicitly use `d` for `document.documentElement` and `c` for `d.classList`.

Also removes a couple of bytes.