### PR TITLE
Add more type safety for Interfaces and components that use theme, themes and resolvedTheme

### DIFF
--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -5,8 +5,8 @@ import React, { useEffect } from 'react'
 let localStorageMock: { [key: string]: string } = {}
 
 // HelperComponent to render the theme inside a paragraph-tag and setting a theme via the forceSetTheme prop
-const HelperComponent = ({ forceSetTheme }: { forceSetTheme?: string }) => {
-  const { setTheme, theme, forcedTheme, resolvedTheme, systemTheme } = useTheme()
+function HelperComponent<T extends string = string>({ forceSetTheme }: { forceSetTheme?: T }) {
+  const { setTheme, theme, forcedTheme, resolvedTheme, systemTheme } = useTheme<T>()
 
   useEffect(() => {
     if (forceSetTheme) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,27 +1,25 @@
-interface ValueObject {
-  [themeName: string]: string
-}
+type ValueObject<T extends string = string> = { [Key in T]?: string }
 
-export interface UseThemeProps {
+export interface UseThemeProps<T extends string = string> {
   /** List of all available theme names */
-  themes: string[]
+  themes: T[]
   /** Forced theme name for the current page */
-  forcedTheme?: string
+  forcedTheme?: T
   /** Update the theme */
   setTheme: (theme: string) => void
   /** Active theme name */
-  theme?: string
+  theme?: T
   /** If `enableSystem` is true and the active theme is "system", this returns whether the system preference resolved to "dark" or "light". Otherwise, identical to `theme` */
-  resolvedTheme?: string
+  resolvedTheme?: T
   /** If enableSystem is true, returns the System theme preference ("dark" or "light"), regardless what the active theme is */
   systemTheme?: 'dark' | 'light'
 }
 
-export interface ThemeProviderProps {
+export interface ThemeProviderProps<T extends string = string> {
   /** List of all available theme names */
-  themes?: string[]
+  themes?: T[]
   /** Forced theme name for the current page */
-  forcedTheme?: string
+  forcedTheme?: T
   /** Whether to switch between dark and light themes based on prefers-color-scheme */
   enableSystem?: boolean
   /** Disable all CSS transitions when switching themes */
@@ -35,7 +33,7 @@ export interface ThemeProviderProps {
   /** HTML attribute modified based on the active theme. Accepts `class` and `data-*` (meaning any data attribute, `data-mode`, `data-color`, etc.) */
   attribute?: string | 'class'
   /** Mapping of theme name to HTML attribute value. Object where key is the theme name and value is the attribute value */
-  value?: ValueObject
+  value?: ValueObject<T>
   /** Nonce string to pass to the inline script for CSP headers */
   nonce?: string
 


### PR DESCRIPTION
First iteration of what we mentioned on the issue #149, maybe we can keep working on it from here.

If it looks fine for you I could add some examples on the readme file or at somewhere else.