### PR TITLE
Fix flash on page load when using value mapping

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -230,7 +230,7 @@ const ThemeScript = memo(
           text += `null`
         }
       } else {
-        if (resolvedName) {
+        if (resolvedName || literal) {
           text += `d[s](n,${val})`
         }
       }


### PR DESCRIPTION
When using value mapping there is a flash on page load (on both development and production). This is due to `updateDOM` function returning empty (`''`) and thus the attribute on `<html>` is not set



### Source of bug

The source of this bug is here:
https://github.com/pacocoursey/next-themes/blob/8fc17e2a53aeb9e5918f8b9152795e56712ea862/src/index.tsx#L233

The condition `if (resolvedName)` is not met when called here:
https://github.com/pacocoursey/next-themes/blob/8fc17e2a53aeb9e5918f8b9152795e56712ea862/src/index.tsx#L252
leaving the `else` block useless

The produced scrept in `ThemeScript` is as follows:
```js
!(function () {
  try {
    var d = document.documentElement,
      n = "data-theme",
      s = "setAttribute";
    var e = localStorage.getItem("theme");
    if ("system" === e || (!e && true)) {
      var t = "(prefers-color-scheme: dark)",
        m = window.matchMedia(t);
      if (m.media !== t || m.matches) {
        d[s](n, "theme-dark");
      } else {
        d[s](n, "theme-light");
      }
    } else if (e) {
      var x = { light: "theme-light", dark: "theme-dark" };
    }
  } catch (e) {}
})();
```

The last if block (`else if (e)`) doesn't do anything on DOM

### Fix
Adding `|| literal` to the condition in `updateDOM` function to also call `setAttribute` when value is passed literally

### Before 
![2023-01-14_1-29-47](https://user-images.githubusercontent.com/46329768/212427221-46bab97e-26f6-447d-8e6b-96762d2b271a.gif)

### After
![2023-01-14_1-32-22](https://user-images.githubusercontent.com/46329768/212427598-04a4013b-0aff-47f4-b235-2a1d8b0e3c26.gif)

