### PR TITLE
simplify code in generated `<script />`. Update index.tsx

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -244,9 +244,7 @@ const ThemeScript = memo(
       }
 
       if (enableSystem) {
-        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if(e==='system'${defaultSystem ? '||!e' : ''}){var t='${MEDIA}',m=window.matchMedia(t);if(m.media!==t||m.matches){${updateDOM(
-          'dark'
-        )}}else{${updateDOM('light')}}}else if(e){${
+        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if(e==='system'${defaultSystem ? '||!e' : ''}){var t='${MEDIA}',m=window.matchMedia(t),s=t!==m.media||m.matches?'dark':'light';${updateDOM('s')}}else if(e){${
           value ? `var x=${JSON.stringify(value)};` : ''
         }${updateDOM(value ? `x[e]` : 'e', true)}}${
           !defaultSystem ? `else{` + updateDOM(defaultTheme, false, false) + '}' : ''

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -244,7 +244,7 @@ const ThemeScript = memo(
       }
 
       if (enableSystem) {
-        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if(e==='system'${defaultSystem ? '||!e' : ''}){var t='${MEDIA}',m=window.matchMedia(t),s=t!==m.media||m.matches?'dark':'light';${updateDOM('s',true)}}else if(e){${
+        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if(e==='system'${defaultSystem ? '||!e' : ''}){var t='${MEDIA}',m=window.matchMedia(t),x=t!==m.media||m.matches?'dark':'light';${updateDOM('x',true)}}else if(e){${
           value ? `var x=${JSON.stringify(value)};` : ''
         }${updateDOM(value ? `x[e]` : 'e', true)}}${
           !defaultSystem ? `else{` + updateDOM(defaultTheme, false, false) + '}' : ''

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -244,7 +244,7 @@ const ThemeScript = memo(
       }
 
       if (enableSystem) {
-        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if(e==='system'${defaultSystem ? '||!e' : ''}){var t='${MEDIA}',m=window.matchMedia(t),s=t!==m.media||m.matches?'dark':'light';${updateDOM('s')}}else if(e){${
+        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if(e==='system'${defaultSystem ? '||!e' : ''}){var t='${MEDIA}',m=window.matchMedia(t),s=t!==m.media||m.matches?'dark':'light';${updateDOM('s',true)}}else if(e){${
           value ? `var x=${JSON.stringify(value)};` : ''
         }${updateDOM(value ? `x[e]` : 'e', true)}}${
           !defaultSystem ? `else{` + updateDOM(defaultTheme, false, false) + '}' : ''

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -244,7 +244,7 @@ const ThemeScript = memo(
       }
 
       if (enableSystem) {
-        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if(e==='system'${defaultSystem ? '||!en' : ''}){var t='${MEDIA}',m=window.matchMedia(t);if(m.media!==t||m.matches){${updateDOM(
+        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if(e==='system'${defaultSystem ? '||!e' : ''}){var t='${MEDIA}',m=window.matchMedia(t);if(m.media!==t||m.matches){${updateDOM(
           'dark'
         )}}else{${updateDOM('light')}}}else if(e){${
           value ? `var x=${JSON.stringify(value)};` : ''

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -244,7 +244,7 @@ const ThemeScript = memo(
       }
 
       if (enableSystem) {
-        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if('system'===e||(!e&&${defaultSystem})){var t='${MEDIA}',m=window.matchMedia(t);if(m.media!==t||m.matches){${updateDOM(
+        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if(e==='system'${defaultSystem ? '||!en' : ''}){var t='${MEDIA}',m=window.matchMedia(t);if(m.media!==t||m.matches){${updateDOM(
           'dark'
         )}}else{${updateDOM('light')}}}else if(e){${
           value ? `var x=${JSON.stringify(value)};` : ''


### PR DESCRIPTION
Currently `next-themes` generate code that can be simplified
<img width="300" alt="image" src="https://user-images.githubusercontent.com/7361780/234687372-a8bc9776-2780-435a-adca-46962cef6204.png">
when `defaultSystem` is `true` => `if (e==='system' || !e)`
when `defaultSystem` is `false` => `if (e==='system')` (no need to check always evaluates to false due `&&` operator

## update:
also below code
<img width="292" alt="image" src="https://user-images.githubusercontent.com/7361780/234692204-86659364-a00e-4f35-aa87-ac0e21541fbc.png">

can be simplified to
![image](https://user-images.githubusercontent.com/7361780/234692096-e96c5fb2-cb12-4c63-a4cf-d2554ec7cedd.png)

## update2

renamed `s` to `x` because it could be reserved https://github.com/B2o5T/next-themes/blob/a199ee818c108185d1590f8552a29be0c9f4f3fa/src/index.tsx#L196