### PR TITLE
fix: add explicit undefined type to support exactOptionalPropertyTypes option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,38 +6,38 @@ export interface UseThemeProps {
   /** List of all available theme names */
   themes: string[]
   /** Forced theme name for the current page */
-  forcedTheme?: string
+  forcedTheme?: string | undefined
   /** Update the theme */
   setTheme: (theme: string) => void
   /** Active theme name */
-  theme?: string
+  theme?: string | undefined
   /** If `enableSystem` is true and the active theme is "system", this returns whether the system preference resolved to "dark" or "light". Otherwise, identical to `theme` */
-  resolvedTheme?: string
+  resolvedTheme?: string | undefined
   /** If enableSystem is true, returns the System theme preference ("dark" or "light"), regardless what the active theme is */
   systemTheme?: 'dark' | 'light'
 }
 
 export interface ThemeProviderProps {
   /** List of all available theme names */
-  themes?: string[]
+  themes?: string[] | undefined
   /** Forced theme name for the current page */
-  forcedTheme?: string
+  forcedTheme?: string | undefined
   /** Whether to switch between dark and light themes based on prefers-color-scheme */
-  enableSystem?: boolean
+  enableSystem?: boolean | undefined
   /** Disable all CSS transitions when switching themes */
-  disableTransitionOnChange?: boolean
+  disableTransitionOnChange?: boolean | undefined
   /** Whether to indicate to browsers which color scheme is used (dark or light) for built-in UI like inputs and buttons */
-  enableColorScheme?: boolean
+  enableColorScheme?: boolean | undefined
   /** Key used to store theme setting in localStorage */
-  storageKey?: string
+  storageKey?: string | undefined
   /** Default theme name (for v0.0.12 and lower the default was light). If `enableSystem` is false, the default theme is light */
-  defaultTheme?: string
+  defaultTheme?: string | undefined
   /** HTML attribute modified based on the active theme. Accepts `class` and `data-*` (meaning any data attribute, `data-mode`, `data-color`, etc.) */
-  attribute?: string | 'class'
+  attribute?: string | 'class' | undefined
   /** Mapping of theme name to HTML attribute value. Object where key is the theme name and value is the attribute value */
-  value?: ValueObject
+  value?: ValueObject | undefined
   /** Nonce string to pass to the inline script for CSP headers */
-  nonce?: string
+  nonce?: string | undefined
 
   children?: React.ReactNode
 }


### PR DESCRIPTION
Thanks for the great library. I am a heavy user of it.

I am having a bit of a problem when I use this library with [@tsconfig/strictest](https://github.com/tsconfig/bases/blob/main/bases/strictest.json#L6). I get "[exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes)" errors in some props.

I have dealt with this in the official TypeScript way.


