### PR TITLE
Update README with note for HTML class attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ That's it, your Next.js app fully supports dark mode, including System preferenc
 }
 ```
 
+> **Note!** If you set the attribute of your Theme Provider to class for Tailwind next-themes will modify the `class` attribute on the `html` element. See [With Tailwind](###with-tailwind).
+
 ### useTheme
 
 Your UI will need to know the current theme and be able to change it. The `useTheme` hook provides theme information:


### PR DESCRIPTION
Some minor clarity and link in the README to help save time for people trying to use next-themes in a CSS file with Tailwind.