### PR TITLE
Modify Check for System Dark Mode Matching

### DIFF
--- a/packages/next-themes/src/index.tsx
+++ b/packages/next-themes/src/index.tsx
@@ -246,7 +246,7 @@ const ThemeScript = memo(
       }
 
       if (enableSystem) {
-        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if('system'===e||(!e&&${defaultSystem})){var t='${MEDIA}',m=window.matchMedia(t);if(m.media!==t||m.matches){${updateDOM(
+        return `!function(){try{${optimization}var e=localStorage.getItem('${storageKey}');if('system'===e||(!e&&${defaultSystem})){var t='${MEDIA}',m=window.matchMedia(t);if(m.media===t||m.matches){${updateDOM(
           'dark'
         )}}else{${updateDOM('light')}}}else if(e){${
           value ? `var x=${JSON.stringify(value)};` : ''


### PR DESCRIPTION
I believe the code has an issue but it is typically not encountered because a fallback condition saves it.

The code here is written as:

```
m=window.matchMedia(t);if(m.media===t||m.matches) { ...
```

If we format it differently it would look something like this:

```
m = window.matchMedia(t);

if (
   m.media === t || 
   m.matches
) { ...
```

If we convert this into better named variables:

```
prefersDarkMode = window.matchMedia("(prefers-color-scheme: dark)");

if (
   prefersDarkMode.media !== "(prefers-color-scheme: dark)" ||
   prefersDarkMode.matches
) { ...
```

This catches my eye since I assume that we actually want to find where `m.media` *does* equal `"(prefers-color-scheme: dark)"`. However, since `m.matches` is likely to be true, the condition succeeds. 

I could be missing the original motivation for why there are two checks versus just one. Perhaps `.matches` is good enough since I don't see how the first condition will be true.