### PR TITLE
Disable transition on pseudo-elements

### DIFF
--- a/packages/next-themes/src/index.tsx
+++ b/packages/next-themes/src/index.tsx
@@ -286,7 +286,7 @@ const disableAnimation = () => {
   const css = document.createElement('style')
   css.appendChild(
     document.createTextNode(
-      `*{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}`
+      `*,*::before,*::after{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}`
     )
   )
   document.head.appendChild(css)


### PR DESCRIPTION
Currently, `disableTransitionOnChange` doesn’t take care of the transitions on pseudo-elements

Example (slowed down):

https://github.com/pacocoursey/next-themes/assets/8441036/cff34eb4-a526-41c1-a867-d3d4816d9a25

This makes sure that transition is disabled for pseudo-elements too:

https://github.com/pacocoursey/next-themes/assets/8441036/21ed2672-c14a-489a-852b-7e1d4575a9a3

