### PR TITLE
Fix Prop nonce did not match error

### DIFF
--- a/packages/next-themes/src/index.tsx
+++ b/packages/next-themes/src/index.tsx
@@ -264,7 +264,10 @@ const ThemeScript = memo(
       )};}${fallbackColorScheme}}catch(t){}}();`
     })()
 
-    return <script nonce={nonce} dangerouslySetInnerHTML={{ __html: scriptSrc }} />
+    // Don't render nonce on client
+    // https://github.com/kentcdodds/nonce-hydration-issues
+    const isServer = typeof window === 'undefined';
+    return <script nonce={isServer ? nonce : ''} dangerouslySetInnerHTML={{ __html: scriptSrc }} />
   },
   // Never re-render this component
   () => true


### PR DESCRIPTION
I am getting ``Warning: Prop `nonce` did not match. Server: "" Client: "rj3157e91u"`` despite passing in a nonce.
When trying to search for why this error is happening I found this: https://github.com/kentcdodds/nonce-hydration-issues
TLDR: Apparently the browser, for security reasons, clears the nonce the way that next-themes is creating script tag. This leads to a mismatch, causing the warning.  

I believe this fixes: https://github.com/pacocoursey/next-themes/issues/218

I have created a build with this fix for testing and it seems to work:
    "@enalmada/next-themes": "^0.2.3",
