### PR TITLE
Update anchor link in Readme.md for proper scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ That's it, your Next.js app fully supports dark mode, including System preferenc
 }
 ```
 
-> **Note!** If you set the attribute of your Theme Provider to class for Tailwind next-themes will modify the `class` attribute on the `html` element. See [With Tailwind](###with-tailwind).
+> **Note!** If you set the attribute of your Theme Provider to class for Tailwind next-themes will modify the `class` attribute on the `html` element. See [With Tailwind](#with-tailwind).
 
 ### useTheme
 


### PR DESCRIPTION
This pull request updates the anchor link in the Readme.md file to ensure proper scrolling to the intended position on the test page.

- Changed the anchor link from ###tailwind to #tailwind in the Readme.md file. (the origin is: https://github.com/pacocoursey/next-themes###with-tailwind)