### PR TITLE
fix: add 'use client' to output code

### DIFF
--- a/packages/next-themes/tsup.config.js
+++ b/packages/next-themes/tsup.config.js
@@ -3,6 +3,9 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   sourcemap: false,
   minify: true,
+  banner: {
+    js: `'use client'`
+  },
   dts: true,
   format: ['esm', 'cjs'],
   loader: {


### PR DESCRIPTION
Adds a `"use client"` banner to the output code to avoid re-exporting it as a client module.
It simplifies the process on not having the Step 2 as described at https://ui.shadcn.com/docs/dark-mode/next.

Also it doesn't break older version because it is just a string which would be ignored anyways