### PR TITLE
Add class for opting out of `disableTransitionOnChange`

### DIFF
--- a/packages/next-themes/src/index.tsx
+++ b/packages/next-themes/src/index.tsx
@@ -286,7 +286,7 @@ const disableAnimation = () => {
   const css = document.createElement('style')
   css.appendChild(
     document.createTextNode(
-      `*{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}`
+      `*:not(.enable-transition-on-change){-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}`
     )
   )
   document.head.appendChild(css)


### PR DESCRIPTION
## Changes
This PR adds option to opt-out from behaviour defined by property `disableTransitionOnChange`. You can add class `enable-transition-on-change` to any element and it will not disable transition during theme switch.

## Motivation:
I have this easter egg on [my CV](https://www.dominikjasek.cz/) and transition of thug life elements doesn't work when switching themes.

Current behaviour:

https://github.com/pacocoursey/next-themes/assets/48070343/cb626f4b-29f9-4a11-88ef-a6f678ba94c4






Behaviour with this PR:

https://github.com/pacocoursey/next-themes/assets/48070343/79a617b8-d0e3-48ce-b0d8-add23ae7ee4f



