### PR TITLE
fix: manually type ThemeProvider to fix type errors

### DIFF
--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -12,7 +12,7 @@ const defaultContext: UseThemeProps = { setTheme: _ => {}, themes: [] }
 
 export const useTheme = () => React.useContext(ThemeContext) ?? defaultContext
 
-export const ThemeProvider = (props: ThemeProviderProps) => {
+export const ThemeProvider = (props: ThemeProviderProps):React.ReactNode => {
   const context = React.useContext(ThemeContext)
 
   // Ignore nested context providers, just passthrough children

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -12,7 +12,7 @@ const defaultContext: UseThemeProps = { setTheme: _ => {}, themes: [] }
 
 export const useTheme = () => React.useContext(ThemeContext) ?? defaultContext
 
-export const ThemeProvider = (props: ThemeProviderProps):React.ReactNode => {
+export const ThemeProvider = (props: ThemeProviderProps): React.ReactNode => {
   const context = React.useContext(ThemeContext)
 
   // Ignore nested context providers, just passthrough children


### PR DESCRIPTION
As of version `0.3.0` I am getting a type error while trying to use ThemeProvider, I fixed it by manually adding return types to ThemeProvider
![image](https://github.com/pacocoursey/next-themes/assets/130567419/8ac535db-a25b-411e-b7f1-b8d41b3ae490)
