### PR TITLE
feat: Output bundled index.{js,mjs,d.ts,d.mts} file instead of seprate files

### DIFF
--- a/next-themes/package.json
+++ b/next-themes/package.json
@@ -8,10 +8,17 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "prepublish": "pnpm build",
-    "build": "tsup src",
-    "dev": "tsup src --watch",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "test": "vitest run __tests__"
   },
   "peerDependencies": {

--- a/next-themes/tsup.config.ts
+++ b/next-themes/tsup.config.ts
@@ -1,16 +1,13 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: {
-    index: 'src/index.tsx'
-  },
+  entry: ['src/index.tsx'],
   sourcemap: false,
   minify: true,
   dts: true,
   clean: true,
   external: ['react'],
   format: ['esm', 'cjs'],
-  loader: {
-    '.js': 'jsx'
-  }
+  splitting: false,
+  bundle: true
 })


### PR DESCRIPTION
Currently the bundler produces several files, I have made it so that everything is bundled in 4 files for single point of import for mjs, cjs and dts.