### PR TITLE
fix: make `children` optional

### DIFF
--- a/next-themes/src/types.ts
+++ b/next-themes/src/types.ts
@@ -19,7 +19,7 @@ export interface UseThemeProps {
   systemTheme?: 'dark' | 'light' | undefined
 }
 
-export interface ThemeProviderProps {
+export interface ThemeProviderProps extends React.PropsWithChildren {
   /** List of all available theme names */
   themes?: string[] | undefined
   /** Forced theme name for the current page */
@@ -40,6 +40,4 @@ export interface ThemeProviderProps {
   value?: ValueObject | undefined
   /** Nonce string to pass to the inline script for CSP headers */
   nonce?: string | undefined
-  /** React children */
-  children: React.ReactNode
 }


### PR DESCRIPTION
Make `children` optional. Because children are not required, as in the following usage, `children` is not passed in explicitly. We can ensure that types is compatible with the original version.

```tsx
const baseContexts: JSX.Element[] = [
  <ThemeProvider key="themeProvider" />, // here, `children` is not passed.
  <JotaiStoreProvider key="jotaiStoreProvider" />,
]

export function WebAppProviders({ children }: PropsWithChildren) {
  return (
    <ProviderComposer contexts={baseContexts}>
      {children}
    </ProviderComposer>
  )
}

export const ProviderComposer: Component<{
  contexts: JSX.Element[]
}> = ({ contexts, children }) => {
  return contexts.reduceRight((kids: any, parent: any) => {
    return React.cloneElement(parent, { children: kids })
  }, children)
}

```

Thanks, @pacocoursey