### PR TITLE
chore: use corepack instead of pnpm setup action in ci

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,12 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
-      - uses: actions/setup-node@v3
+      - name: Enable corepack
+        run: corepack enable
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'pnpm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
-
+      - name: Enable corepack
+        run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x


### PR DESCRIPTION
PNPM versioning is quite the pain with lock-files being incompatible between patch versions.
Instead of manually specifing the pnpm version and running the pnpm setup action is replaced with simply enableing corepack.

