### PR TITLE
Allow mapping to multiple class names

### DIFF
--- a/next-themes/README.md
+++ b/next-themes/README.md
@@ -256,6 +256,14 @@ If we want the DOM to instead render `data-theme="my-pink-theme"` when the theme
 
 Done! To be extra clear, this affects only the DOM. Here's how all the values will look:
 
+if we want to map a theme to multiple custom theme values, we can simply pass an array:
+```jsx
+<ThemeProvider attribute='class' value={{ pink: ['my-pink-theme', 'another-pink-theme'] }}>
+```
+
+When the selected theme is `pink`, both `my-pink-theme` and `another-pink-theme` will be added as class names.
+
+
 ```js
 const { theme } = useTheme()
 // => "pink"

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -54,7 +54,7 @@ const Theme = ({
 
     const handleAttribute = (attr: Attribute) => {
       if (attr === 'class') {
-        d.classList.remove(...attrs)
+        d.classList.remove(...attrs.flat())
         if (names) d.classList.add(...names)
       } else if (attr.startsWith('data-')) {
         if (names) {

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -48,14 +48,14 @@ const Theme = ({
       resolved = getSystemTheme()
     }
 
-    const names = [value ? value[resolved] : resolved].flat()
+    const names = [value ? value[resolved] ?? [] : resolved].flat()
     const enable = disableTransitionOnChange ? disableAnimation() : null
     const d = document.documentElement
 
     const handleAttribute = (attr: Attribute) => {
       if (attr === 'class') {
         d.classList.remove(...attrs.flat())
-        if (names) d.classList.add(...names)
+        if (names.length) d.classList.add(...names)
       } else if (attr.startsWith('data-')) {
         if (names.length) {
           d.setAttribute(attr, names.join(' '))

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -57,7 +57,7 @@ const Theme = ({
         d.classList.remove(...attrs.flat())
         if (names) d.classList.add(...names)
       } else if (attr.startsWith('data-')) {
-        if (names) {
+        if (names.length) {
           d.setAttribute(attr, names.join(' '))
         } else {
           d.removeAttribute(attr)

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -39,7 +39,7 @@ const Theme = ({
   const [resolvedTheme, setResolvedTheme] = React.useState(() => getTheme(storageKey))
   const attrs = !value ? themes : Object.values(value)
 
-  const applyTheme = React.useCallback(theme => {
+  const applyTheme = React.useCallback((theme: string) => {
     let resolved = theme
     if (!resolved) return
 
@@ -48,7 +48,7 @@ const Theme = ({
       resolved = getSystemTheme()
     }
 
-    const names = value ? Array.isArray(value[resolved]) ? value[resolved] : [value[resolved]] : resolved
+    const names = value ? Array.isArray(value[resolved]) ? value[resolved] : [value[resolved]] : [resolved]
     const enable = disableTransitionOnChange ? disableAnimation() : null
     const d = document.documentElement
 

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -48,17 +48,17 @@ const Theme = ({
       resolved = getSystemTheme()
     }
 
-    const name = value ? value[resolved] : resolved
+    const names = value ? Array.isArray(value[resolved]) ? value[resolved] : [value[resolved]] : resolved
     const enable = disableTransitionOnChange ? disableAnimation() : null
     const d = document.documentElement
 
     const handleAttribute = (attr: Attribute) => {
       if (attr === 'class') {
         d.classList.remove(...attrs)
-        if (name) d.classList.add(name)
+        if (names) d.classList.add(...names)
       } else if (attr.startsWith('data-')) {
-        if (name) {
-          d.setAttribute(attr, name)
+        if (names) {
+          d.setAttribute(attr, names.join(' '))
         } else {
           d.removeAttribute(attr)
         }

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -48,7 +48,7 @@ const Theme = ({
       resolved = getSystemTheme()
     }
 
-    const names = value ? Array.isArray(value[resolved]) ? value[resolved] : [value[resolved]] : [resolved]
+    const names = [value ? value[resolved] : resolved].flat()
     const enable = disableTransitionOnChange ? disableAnimation() : null
     const d = document.documentElement
 

--- a/next-themes/src/types.ts
+++ b/next-themes/src/types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 interface ValueObject {
-  [themeName: string]: string
+  [themeName: string]: string | string[]
 }
 
 export interface UseThemeProps {

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "node": ">=20",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@9.1.4"
+  "packageManager": "pnpm@9.0.6"
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "node": ">=20",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@9.0.6"
+  "packageManager": "pnpm@9.1.4"
 }


### PR DESCRIPTION
Fixes: https://github.com/pacocoursey/next-themes/issues/292 https://github.com/pacocoursey/next-themes/issues/221

This PR would allow users to map one theme to multiple custom classes.

The `value` can now accept a `string` or `string[]` as value.

if we want to map a theme to multiple custom theme values, we can simply pass an array:
```jsx
<ThemeProvider attribute='class' value={{ pink: ['my-pink-theme', 'another-pink-theme'] }}>
```

When the selected theme is `pink`, both `my-pink-theme` and `another-pink-theme` will be added as class names.
