### PR TITLE
fix: support multiple attributes in the injection script

### DIFF
--- a/next-themes/__tests__/index.test.tsx
+++ b/next-themes/__tests__/index.test.tsx
@@ -236,6 +236,19 @@ describe('custom attribute', () => {
 
     expect(document.documentElement.getAttribute('data-example')).toBe('light')
   })
+
+  test('supports multiple attributes', () => {
+    act(() => {
+      render(
+        <ThemeProvider attribute={['data-example', 'data-theme-test']}>
+          <HelperComponent forceSetTheme="light" />
+        </ThemeProvider>
+      )
+    })
+
+    expect(document.documentElement.getAttribute('data-example')).toBe('light')
+    expect(document.documentElement.getAttribute('data-theme-test')).toBe('light')
+  })
 })
 
 describe('custom value-mapping', () => {
@@ -279,6 +292,23 @@ describe('custom value-mapping', () => {
     })
 
     expect(document.documentElement.classList.contains('light')).toBeFalsy()
+  })
+
+  test('supports multiple attributes', () => {
+    act(() => {
+      render(
+        <ThemeProvider
+          attribute={['data-example', 'data-theme-test']}
+          themes={['pink', 'light', 'dark', 'system']}
+          value={{ pink: 'my-pink-theme' }}
+        >
+          <HelperComponent forceSetTheme="pink" />
+        </ThemeProvider>
+      )
+    })
+
+    expect(document.documentElement.getAttribute('data-example')).toBe('my-pink-theme')
+    expect(document.documentElement.getAttribute('data-theme-test')).toBe('my-pink-theme')
   })
 })
 
@@ -429,5 +459,4 @@ describe('setTheme', () => {
     expect(result.current.theme).toBe('light')
     expect(result.current.resolvedTheme).toBe('light')
   })
-
 })

--- a/next-themes/src/script.ts
+++ b/next-themes/src/script.ts
@@ -10,16 +10,20 @@ export const script = (
 ) => {
   const el = document.documentElement
   const systemThemes = ['light', 'dark']
-  const isClass = attribute === 'class'
-  const classes = isClass && value ? themes.map(t => value[t] || t) : themes
 
   function updateDOM(theme: string) {
-    if (isClass) {
-      el.classList.remove(...classes)
-      el.classList.add(theme)
-    } else {
-      el.setAttribute(attribute, theme)
-    }
+    const attributes = Array.isArray(attribute) ? attribute : [attribute]
+
+    attributes.forEach(attr => {
+      const isClass = attr === 'class'
+      const classes = isClass && value ? themes.map(t => value[t] || t) : themes
+      if (isClass) {
+        el.classList.remove(...classes)
+        el.classList.add(theme)
+      } else {
+        el.setAttribute(attr, theme)
+      }
+    })
 
     setColorScheme(theme)
   }


### PR DESCRIPTION
PR #275 added support for multiple attributes in applyTheme, but missed handling it in the injection script. This caused page flashes when attribute prop is an array in ThemeProvider. This PR fixes that.

