### PR TITLE
feat: add react v19 to peer deps

### DIFF
--- a/next-themes/package.json
+++ b/next-themes/package.json
@@ -22,8 +22,8 @@
     "test": "vitest run __tests__"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17 || ^18",
-    "react-dom": "^16.8 || ^17 || ^18"
+    "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
   },
   "devDependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
Thanks a lot for this package

I get the following warning from pnpm after upgrading to NextJS v15 (released today), which installs react 19 RC

React 19 is technically still in RC stage, but since a stable version of a major Metaframework is installing it, it's a sign that it's ready for production use and will now be used by many projects.

```ts
│ └─┬ next-themes 0.3.0
│   ├── ✕ unmet peer react@"^16.8 || ^17 || ^18": found 19.0.0-rc-65a56d0e-20241020
│   └── ✕ unmet peer react-dom@"^16.8 || ^17 || ^18": found 19.0.0-rc-65a56d0e-20241020
```
