### PR TITLE
Re-export types from `next-themes`

### DIFF
--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -245,3 +245,6 @@ const getSystemTheme = (e?: MediaQueryList | MediaQueryListEvent) => {
   const systemTheme = isDark ? 'dark' : 'light'
   return systemTheme
 }
+
+// Re-export types
+export type { Attribute, ThemeProviderProps, UseThemeProps } from './types'


### PR DESCRIPTION
**Before**
```tsx
import { ThemeProvider, useTheme } from 'next-themes'

export type ThemeProviderProps = React.ComponentProps<typeof ThemeProvider>

export function ColorModeProvider(props: ThemeProviderProps) {
  return <ThemeProvider attribute="class" disableTransitionOnChange {...props} />
}
```

**After**
```tsx
import { ThemeProvider, useTheme, type ThemeProviderProps } from 'next-themes'

export function ColorModeProvider(props: ThemeProviderProps) {
  return <ThemeProvider attribute="class" disableTransitionOnChange {...props} />
}
```