### PR TITLE
fix: infinite loop theme flicker

### DIFF
--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -125,8 +125,11 @@ const Theme = ({
       }
 
       // If default theme set, use it if localstorage === null (happens on local storage manual deletion)
-      const theme = e.newValue || defaultTheme
-      setTheme(theme)
+      if (!e.newValue) {
+        setTheme(defaultTheme)
+      } else {
+        setThemeState(e.newValue) // Direct state update to avoid loops
+      }
     }
 
     window.addEventListener('storage', handleStorage)


### PR DESCRIPTION
There was an issue where sometimes the theme change would fall into infinite loop switching between the light/dark theme causing constant flashing. This issue could be reproduced by opening multiple tabs of the same app and quickly changing the theme many times. 

The root cause was that the "storage" listener in tab A would update the local storage, so the tab B would get an event and update the local storage, and then tab A would get an event...and so on. Somewhere along the way had to be some kind of race condition where the theme between the tabs would get out of sync causing the constant flashing back and forth.

To fix that I've swapped the `setTheme` with `setThemeState` in the storage listener, and only use `setTheme` to handle the case where the local storage entry is manually removed

CLOSES #85
CLOSES #323