### PR TITLE
fix: map theme to class using ValueObject in injected script

### DIFF
--- a/next-themes/src/script.ts
+++ b/next-themes/src/script.ts
@@ -19,7 +19,7 @@ export const script = (
       const classes = isClass && value ? themes.map(t => value[t] || t) : themes
       if (isClass) {
         el.classList.remove(...classes)
-        el.classList.add(theme)
+        el.classList.add(value[theme] || theme)
       } else {
         el.setAttribute(attr, theme)
       }


### PR DESCRIPTION
I think this is a bug: the CSS classes are being correctly remapped in order to _remove_ them all, but the class being added is not mapped using the `ValueObject`:

https://github.com/pacocoursey/next-themes/blob/57c0561b1fac95fab0a951adf1bc74f21e24c91c/next-themes/src/script.ts#L19-L22