### PR TITLE
Reduce number of renders by pre-setting resolvedTheme

### DIFF
--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -37,7 +37,7 @@ const Theme = ({
   scriptProps
 }: ThemeProviderProps) => {
   const [theme, setThemeState] = React.useState(() => getTheme(storageKey, defaultTheme))
-  const [resolvedTheme, setResolvedTheme] = React.useState(() => getTheme(storageKey))
+  const [resolvedTheme, setResolvedTheme] = React.useState(() => theme === 'system' ? getSystemTheme() : theme)
   const attrs = !value ? themes : Object.values(value)
 
   const applyTheme = React.useCallback(theme => {


### PR DESCRIPTION
Hey! Was checking some react profiles and saw that this sort of forcibly causes an extra render if setTheme hasn't been called before. This code change saves that by pre-resolving it to the right one.