### PR TITLE
fix initial load class mismatch

### DIFF
--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -41,7 +41,7 @@ const Theme = ({
   const attrs = !value ? themes : Object.values(value)
 
   const applyTheme = React.useCallback(theme => {
-    let resolved = theme
+    let resolved = value ? value[theme] : theme
     if (!resolved) return
 
     // If theme is system, resolve it before setting theme


### PR DESCRIPTION
I think this is a bug. (needs confirmation)

1. Local storage value is `dark`.

2. Usage looks like
```tsx
    <ThemeProviderPrimitive
      storageKey={STORAGE_KEY}
      attribute="class"
      defaultTheme="system"
      enableSystem
      value={{
        dark: "dark-bug", 
        system: "system",
        light: "light-bug", 
      }}
      {...props}
    >
      {children}
    </ThemeProviderPrimitive>
```

3. Short video depicting multiple page refreshes.


https://github.com/user-attachments/assets/bb6007bc-fb34-478b-985b-427fb46461e4

