### PR TITLE
fix: add null check for value in updateDOM function to prevent runtime errors and flashing

### DIFF
--- a/next-themes/src/script.ts
+++ b/next-themes/src/script.ts
@@ -19,7 +19,7 @@ export const script = (
       const classes = isClass && value ? themes.map(t => value[t] || t) : themes
       if (isClass) {
         el.classList.remove(...classes)
-        el.classList.add(value[theme] || theme)
+        el.classList.add(value && value[theme] ? value[theme] : theme)
       } else {
         el.setAttribute(attr, theme)
       }


### PR DESCRIPTION
### Summary

This pull request addresses a potential issue in the `updateDOM` function where accessing the `value[theme]` property could result in a runtime error if `value` is `null` or `undefined`. The fix introduces a null check to ensure `value` is truthy before accessing its properties. Additionally, this change prevents flashing of themes by ensuring that the class list updates correctly.

### Changes

- Updated the `updateDOM` function to use the following check:

```javascript
el.classList.add(value && value[theme] ? value[theme] : theme);
```

### Reason for Change

The previous implementation did not account for the possibility of `value` being `null` or `undefined`, which could lead to runtime errors. This fix makes the code more robust by preventing such errors. It also addresses the issue of theme flashing by ensuring that the class list is properly managed.

### Additional Notes

This change improves the overall stability of the theme management script by handling edge cases more gracefully and preventing visual issues like theme flashing.
