### PR TITLE
fix: #346 ensure `setTheme` Receives the Latest State

### DIFF
--- a/next-themes/__tests__/index.test.tsx
+++ b/next-themes/__tests__/index.test.tsx
@@ -459,6 +459,32 @@ describe('setTheme', () => {
     expect(result.current.theme).toBe('light')
     expect(result.current.resolvedTheme).toBe('light')
   })
+
+  test('setTheme(<function>) gets relevant state value', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { })
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => <ThemeProvider defaultTheme="light">{children}</ThemeProvider>
+    })
+
+    act(() => {
+      result.current.setTheme((theme) => {
+        console.log('1', theme)
+        return theme === 'dark' ? 'light' : 'dark'
+      })
+      result.current.setTheme((theme) => {
+        console.log('2', theme)
+        return theme === 'light' ? 'dark' : 'light'
+      })
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith('1', 'light')
+    expect(consoleSpy).toHaveBeenCalledWith('2', 'dark')
+    expect(result.current.theme).toBe('light')
+
+    consoleSpy.mockRestore()
+  })
+
 })
 
 describe('inline script', () => {


### PR DESCRIPTION
This PR fixes the issue I mentioned here [#346](https://github.com/pacocoursey/next-themes/issues/346).

#### Bug  
When passing a function to `setTheme`, it receives an outdated state value. This happens because the function is closed over `theme`, leading to incorrect behavior when updating the theme multiple times within the same render cycle. Each `setState` call computes the same value instead of using the latest state.  

#### Fix  
- Rewrote the `setTheme` function to ensure it correctly handles functional updates.  
- Added tests to cover this edge case.  

This fix ensures that `setTheme` behaves as expected when called multiple times in a single render.