### PR TITLE
Add option to opt-out of automatic script insertion

### DIFF
--- a/next-themes/__tests__/index.test.tsx
+++ b/next-themes/__tests__/index.test.tsx
@@ -5,7 +5,7 @@ import { act, render, renderHook, screen } from '@testing-library/react'
 import { vi, beforeAll, beforeEach, afterEach, afterAll, describe, test, it, expect } from 'vitest'
 import { cleanup } from '@testing-library/react'
 
-import { ThemeProvider, ThemeScript, useTheme } from '../src/index'
+import { ThemeProvider, useTheme } from '../src/index'
 import { ThemeProviderProps } from '../src/types'
 
 let originalLocalStorage: Storage

--- a/next-themes/__tests__/index.test.tsx
+++ b/next-themes/__tests__/index.test.tsx
@@ -77,6 +77,8 @@ beforeEach(() => {
   setDeviceTheme('light')
   document.documentElement.style.colorScheme = ''
   document.documentElement.removeAttribute('data-theme')
+  document.documentElement.removeAttribute('data-theme-test')
+  document.documentElement.removeAttribute('data-example')
   document.documentElement.removeAttribute('class')
 
   // Clear the localStorage-mock

--- a/next-themes/__tests__/index.test.tsx
+++ b/next-themes/__tests__/index.test.tsx
@@ -501,9 +501,6 @@ describe('inline script', () => {
 
     expect(document.querySelector('script[data-test="1234"]')).toBeTruthy()
   })
-})
-
-describe('manual script insertion', () => {
   test('should not insert script when `withScript` is false', () => {
     act(() => {
       render(

--- a/next-themes/__tests__/index.test.tsx
+++ b/next-themes/__tests__/index.test.tsx
@@ -515,18 +515,4 @@ describe('manual script insertion', () => {
     })
     expect(document.querySelector('script[data-test="1234"]')).toBeFalsy()
   })
-  it('should work with manual script insertion', () => {
-    const { result } = renderHook(() => useTheme(), {
-      wrapper: ({ children }) => (
-        <ThemeProvider withScript={false} defaultTheme="dark">
-          <ThemeScript defaultTheme="dark" scriptProps={{ 'data-test': '4567' }} />
-          {children}
-        </ThemeProvider>
-      )
-    })
-
-    expect(result.current.theme).toBe('dark')
-    expect(result.current.resolvedTheme).toBe('dark')
-    expect(document.querySelector('script[data-test="4567"]')).toBeTruthy()
-  })
 })

--- a/next-themes/__tests__/index.test.tsx
+++ b/next-themes/__tests__/index.test.tsx
@@ -5,7 +5,7 @@ import { act, render, renderHook, screen } from '@testing-library/react'
 import { vi, beforeAll, beforeEach, afterEach, afterAll, describe, test, it, expect } from 'vitest'
 import { cleanup } from '@testing-library/react'
 
-import { ThemeProvider, useTheme } from '../src/index'
+import { ThemeProvider, ThemeScript, useTheme } from '../src/index'
 import { ThemeProviderProps } from '../src/types'
 
 let originalLocalStorage: Storage
@@ -498,5 +498,35 @@ describe('inline script', () => {
     })
 
     expect(document.querySelector('script[data-test="1234"]')).toBeTruthy()
+  })
+})
+
+describe('manual script insertion', () => {
+  test('should not insert script when `withScript` is false', () => {
+    act(() => {
+      render(
+        <ThemeProvider
+          withScript={false}
+          scriptProps={{ 'data-test': '1234' }}
+        >
+          <div />
+        </ThemeProvider>
+      )
+    })
+    expect(document.querySelector('script[data-test="1234"]')).toBeFalsy()
+  })
+  it('should work with manual script insertion', () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ({ children }) => (
+        <ThemeProvider withScript={false} defaultTheme="dark">
+          <ThemeScript defaultTheme="dark" scriptProps={{ 'data-test': '4567' }} />
+          {children}
+        </ThemeProvider>
+      )
+    })
+
+    expect(result.current.theme).toBe('dark')
+    expect(result.current.resolvedTheme).toBe('dark')
+    expect(document.querySelector('script[data-test="4567"]')).toBeTruthy()
   })
 })

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -51,12 +51,14 @@ const Theme = ({
   const attrs = !value ? themes : Object.values(value)
 
   const isThemeCurrentTheme = (theme: string) => {
-    const attr = Array.isArray(attribute) ? attribute[0] : attribute
-    if (!attr) return false
-    if (attr === 'class') {
-      return document.documentElement.classList.contains(theme)
-    }
-    return document.documentElement.getAttribute(attr) === theme
+    const attributes = Array.isArray(attribute) ? attribute : [attribute]
+    if (!attributes) return false
+    return attributes.every(attr => {
+      if (attr === 'class') {
+        return document.documentElement.classList.contains(theme)
+      }
+      return document.documentElement.getAttribute(attr) === theme
+    });
   }
 
   const applyTheme = React.useCallback(theme => {

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -226,7 +226,7 @@ export const ThemeScript = React.memo(
 // Helpers
 const getTheme = (key: string, fallback?: string) => {
   if (isServer) return undefined
-  let theme: string | undefined
+  let theme
   try {
     theme = localStorage.getItem(key) || undefined
   } catch (e) {
@@ -257,8 +257,8 @@ const disableAnimation = (nonce?: string) => {
 }
 
 const getSystemTheme = (e?: MediaQueryList | MediaQueryListEvent) => {
-  const match = e || window.matchMedia(MEDIA)
-  const isDark = match.matches
+  if (!e) e = window.matchMedia(MEDIA)
+  const isDark = e.matches
   const systemTheme = isDark ? 'dark' : 'light'
   return systemTheme
 }

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -104,10 +104,10 @@ const Theme = ({
     enable?.()
   }, [nonce])
 
-  const setTheme: React.Dispatch<React.SetStateAction<string>> = React.useCallback(value => {
+  const setTheme = React.useCallback(value => {
     if (typeof value === 'function') {
       setThemeState(prevTheme => {
-        const newTheme = value(prevTheme as string)
+        const newTheme = value(prevTheme)
 
         saveToLS(storageKey, newTheme)
 

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -202,7 +202,7 @@ const Theme = ({
   )
 }
 
-const ThemeScript = React.memo(
+export const ThemeScript = React.memo(
   ({
     forcedTheme,
     storageKey,

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -177,7 +177,7 @@ const Theme = ({
             value,
             themes,
             nonce,
-            scriptProps,
+            scriptProps
           }}
         />
       ) : null}
@@ -197,7 +197,7 @@ export const ThemeScript = React.memo(
     value,
     themes,
     nonce,
-    scriptProps,
+    scriptProps
   }: Omit<ThemeProviderProps, 'children'> & { defaultTheme: string }) => {
     const scriptArgs = JSON.stringify([
       attribute,

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -8,7 +8,7 @@ const colorSchemes = ['light', 'dark']
 const MEDIA = '(prefers-color-scheme: dark)'
 const isServer = typeof window === 'undefined'
 const ThemeContext = React.createContext<UseThemeProps | undefined>(undefined)
-const defaultContext: UseThemeProps = { setTheme: _ => {}, themes: [] }
+const defaultContext: UseThemeProps = { setTheme: _ => { }, themes: [] }
 
 const saveToLS = (storageKey: string, value: string) => {
   // Save to storage
@@ -47,9 +47,7 @@ const Theme = ({
   scriptProps
 }: ThemeProviderProps) => {
   const [theme, setThemeState] = React.useState(() => getTheme(storageKey, defaultTheme))
-  const [resolvedTheme, setResolvedTheme] = React.useState(() =>
-    theme === 'system' ? getSystemTheme() : theme
-  )
+  const [resolvedTheme, setResolvedTheme] = React.useState(() => theme === 'system' ? getSystemTheme() : theme)
   const attrs = !value ? themes : Object.values(value)
 
   const isThemeCurrentTheme = (theme: string) => {
@@ -61,52 +59,49 @@ const Theme = ({
     return document.documentElement.getAttribute(attr) === theme
   }
 
-  const applyTheme = React.useCallback(
-    (theme: string | undefined) => {
-      let resolved = theme
-      if (!resolved) return
+  const applyTheme = React.useCallback(theme => {
+    let resolved = theme
+    if (!resolved) return
 
-      // If theme is system, resolve it before setting theme
-      if (theme === 'system' && enableSystem) {
-        resolved = getSystemTheme()
-      }
+    // If theme is system, resolve it before setting theme
+    if (theme === 'system' && enableSystem) {
+      resolved = getSystemTheme()
+    }
 
-      // Avoid additional work, if no changes need to be made.
-      // In particular, this avoids the `disableAnimation` call,
-      // which is expensive.
-      if (isThemeCurrentTheme(resolved)) return
+    // Avoid additional work, if no changes need to be made.
+    // In particular, this avoids the `disableAnimation` call,
+    // which is expensive.
+    if (isThemeCurrentTheme(resolved)) return
 
-      const name = value ? value[resolved] : resolved
-      const enable = disableTransitionOnChange ? disableAnimation(nonce) : null
-      const d = document.documentElement
+    const name = value ? value[resolved] : resolved
+    const enable = disableTransitionOnChange ? disableAnimation(nonce) : null
+    const d = document.documentElement
 
-      const handleAttribute = (attr: Attribute) => {
-        if (attr === 'class') {
-          d.classList.remove(...attrs)
-          if (name) d.classList.add(name)
-        } else if (attr.startsWith('data-')) {
-          if (name) {
-            d.setAttribute(attr, name)
-          } else {
-            d.removeAttribute(attr)
-          }
+    const handleAttribute = (attr: Attribute) => {
+      if (attr === 'class') {
+        d.classList.remove(...attrs)
+        if (name) d.classList.add(name)
+      } else if (attr.startsWith('data-')) {
+        if (name) {
+          d.setAttribute(attr, name)
+        } else {
+          d.removeAttribute(attr)
         }
       }
+    }
 
-      if (Array.isArray(attribute)) attribute.forEach(handleAttribute)
-      else handleAttribute(attribute)
+    if (Array.isArray(attribute)) attribute.forEach(handleAttribute)
+    else handleAttribute(attribute)
 
-      if (enableColorScheme) {
-        const fallback = colorSchemes.includes(defaultTheme) ? defaultTheme : null
-        const colorScheme = colorSchemes.includes(resolved) ? resolved : fallback
-        // @ts-ignore
-        d.style.colorScheme = colorScheme
-      }
+    if (enableColorScheme) {
+      const fallback = colorSchemes.includes(defaultTheme) ? defaultTheme : null
+      const colorScheme = colorSchemes.includes(resolved) ? resolved : fallback
+      // @ts-ignore
+      d.style.colorScheme = colorScheme
+    }
 
-      enable?.()
-    },
-    [nonce]
-  )
+    enable?.()
+  }, [nonce])
 
   const setTheme: React.Dispatch<React.SetStateAction<string>> = React.useCallback(value => {
     if (typeof value === 'function') {
@@ -205,7 +200,7 @@ const Theme = ({
   )
 }
 
-export const ThemeScript = React.memo(
+const ThemeScript = React.memo(
   ({
     forcedTheme,
     storageKey,
@@ -235,9 +230,7 @@ export const ThemeScript = React.memo(
         {...scriptProps}
         suppressHydrationWarning
         nonce={typeof window === 'undefined' ? nonce : ''}
-        dangerouslySetInnerHTML={{
-          __html: `(${script.toString()})(${scriptArgs})`
-        }}
+        dangerouslySetInnerHTML={{ __html: `(${script.toString()})(${scriptArgs})` }}
       />
     )
   }
@@ -267,7 +260,7 @@ const disableAnimation = (nonce?: string) => {
 
   return () => {
     // Force restyle
-    ;(() => window.getComputedStyle(document.body))()
+    ; (() => window.getComputedStyle(document.body))()
 
     // Wait for next tick before removing
     setTimeout(() => {

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -50,16 +50,6 @@ const Theme = ({
   const [resolvedTheme, setResolvedTheme] = React.useState(() => theme === 'system' ? getSystemTheme() : theme)
   const attrs = !value ? themes : Object.values(value)
 
-  const isThemeCurrentTheme = (theme: string) => {
-    const attributes = Array.isArray(attribute) ? attribute : [attribute]
-    return attributes.every(attr => {
-      if (attr === 'class') {
-        return document.documentElement.classList.contains(theme)
-      }
-      return document.documentElement.getAttribute(attr) === theme
-    });
-  }
-
   const applyTheme = React.useCallback(theme => {
     let resolved = theme
     if (!resolved) return
@@ -68,11 +58,6 @@ const Theme = ({
     if (theme === 'system' && enableSystem) {
       resolved = getSystemTheme()
     }
-
-    // Avoid additional work, if no changes need to be made.
-    // In particular, this avoids the `disableAnimation` call,
-    // which is expensive.
-    if (isThemeCurrentTheme(resolved)) return
 
     const name = value ? value[resolved] : resolved
     const enable = disableTransitionOnChange ? disableAnimation(nonce) : null

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -206,14 +206,15 @@ export const ThemeScript = React.memo(
   ({
     forcedTheme,
     storageKey,
-    attribute = 'data-theme',
-    enableSystem = true,
-    enableColorScheme = true,
-    defaultTheme = enableSystem ? 'system' : 'light',
+    attribute,
+    enableSystem,
+    enableColorScheme,
+    defaultTheme,
     value,
-    themes = defaultThemes,
+    themes,
     nonce,
-    scriptProps
+    scriptProps,
+    id
   }: Omit<ThemeProviderProps, 'children'> & { defaultTheme: string }) => {
     const scriptArgs = JSON.stringify([
       attribute,
@@ -228,7 +229,7 @@ export const ThemeScript = React.memo(
 
     return (
       <script
-        id="theme-script"
+        id={id}
         {...scriptProps}
         suppressHydrationWarning
         nonce={typeof window === 'undefined' ? nonce : ''}

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -52,7 +52,6 @@ const Theme = ({
 
   const isThemeCurrentTheme = (theme: string) => {
     const attributes = Array.isArray(attribute) ? attribute : [attribute]
-    if (!attributes) return false
     return attributes.every(attr => {
       if (attr === 'class') {
         return document.documentElement.classList.contains(theme)

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -45,7 +45,6 @@ const Theme = ({
   children,
   nonce,
   scriptProps,
-  id
 }: ThemeProviderProps) => {
   const [theme, setThemeState] = React.useState(() => getTheme(storageKey, defaultTheme))
   const [resolvedTheme, setResolvedTheme] = React.useState(() => theme === 'system' ? getSystemTheme() : theme)
@@ -179,7 +178,6 @@ const Theme = ({
             themes,
             nonce,
             scriptProps,
-            id
           }}
         />
       ) : null}
@@ -200,7 +198,6 @@ export const ThemeScript = React.memo(
     themes,
     nonce,
     scriptProps,
-    id
   }: Omit<ThemeProviderProps, 'children'> & { defaultTheme: string }) => {
     const scriptArgs = JSON.stringify([
       attribute,
@@ -215,7 +212,6 @@ export const ThemeScript = React.memo(
 
     return (
       <script
-        id={id}
         {...scriptProps}
         suppressHydrationWarning
         nonce={typeof window === 'undefined' ? nonce : ''}

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -44,7 +44,8 @@ const Theme = ({
   value,
   children,
   nonce,
-  scriptProps
+  scriptProps,
+  id
 }: ThemeProviderProps) => {
   const [theme, setThemeState] = React.useState(() => getTheme(storageKey, defaultTheme))
   const [resolvedTheme, setResolvedTheme] = React.useState(() => theme === 'system' ? getSystemTheme() : theme)
@@ -177,7 +178,8 @@ const Theme = ({
             value,
             themes,
             nonce,
-            scriptProps
+            scriptProps,
+            id
           }}
         />
       ) : null}

--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -44,7 +44,7 @@ const Theme = ({
   value,
   children,
   nonce,
-  scriptProps,
+  scriptProps
 }: ThemeProviderProps) => {
   const [theme, setThemeState] = React.useState(() => getTheme(storageKey, defaultTheme))
   const [resolvedTheme, setResolvedTheme] = React.useState(() => theme === 'system' ? getSystemTheme() : theme)

--- a/next-themes/src/script.ts
+++ b/next-themes/src/script.ts
@@ -1,16 +1,15 @@
 export const script = (
-  attribute,
-  storageKey,
-  defaultTheme,
-  forcedTheme,
-  themes,
-  value,
-  enableSystem,
-  enableColorScheme
-) => {
+  attribute: string | string[],
+  storageKey: string,
+  defaultTheme: string,
+  forcedTheme: string,
+  themes: string[],
+  value: Record<string, string>,
+  enableSystem: boolean,
+  enableColorScheme: boolean
+): void => {
   const el = document.documentElement
   const systemThemes = ['light', 'dark']
-
   function updateDOM(theme: string) {
     const attributes = Array.isArray(attribute) ? attribute : [attribute]
 
@@ -19,7 +18,7 @@ export const script = (
       const classes = isClass && value ? themes.map(t => value[t] || t) : themes
       if (isClass) {
         el.classList.remove(...classes)
-        el.classList.add(value && value[theme] ? value[theme] : theme)
+        el.classList.add(value?.[theme] ? value[theme] : theme)
       } else {
         el.setAttribute(attr, theme)
       }
@@ -34,7 +33,7 @@ export const script = (
     }
   }
 
-  function getSystemTheme() {
+  function getSystemTheme(): string {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
   }
 
@@ -46,8 +45,6 @@ export const script = (
       const isSystem = enableSystem && themeName === 'system'
       const theme = isSystem ? getSystemTheme() : themeName
       updateDOM(theme)
-    } catch (e) {
-      //
-    }
+    } catch (e) {}
   }
 }

--- a/next-themes/src/script.ts
+++ b/next-themes/src/script.ts
@@ -10,6 +10,7 @@ export const script = (
 ): void => {
   const el = document.documentElement
   const systemThemes = ['light', 'dark']
+
   function updateDOM(theme: string) {
     const attributes = Array.isArray(attribute) ? attribute : [attribute]
 
@@ -45,6 +46,8 @@ export const script = (
       const isSystem = enableSystem && themeName === 'system'
       const theme = isSystem ? getSystemTheme() : themeName
       updateDOM(theme)
-    } catch (e) {}
+    } catch (e) {
+      //
+    }
   }
 }

--- a/next-themes/src/script.ts
+++ b/next-themes/src/script.ts
@@ -1,13 +1,13 @@
 export const script = (
-  attribute: string | string[],
-  storageKey: string,
-  defaultTheme: string,
-  forcedTheme: string,
-  themes: string[],
-  value: Record<string, string>,
-  enableSystem: boolean,
-  enableColorScheme: boolean
-): void => {
+  attribute,
+  storageKey,
+  defaultTheme,
+  forcedTheme,
+  themes,
+  value,
+  enableSystem,
+  enableColorScheme
+) => {
   const el = document.documentElement
   const systemThemes = ['light', 'dark']
 
@@ -19,7 +19,7 @@ export const script = (
       const classes = isClass && value ? themes.map(t => value[t] || t) : themes
       if (isClass) {
         el.classList.remove(...classes)
-        el.classList.add(value?.[theme] ? value[theme] : theme)
+        el.classList.add(value && value[theme] ? value[theme] : theme)
       } else {
         el.setAttribute(attr, theme)
       }
@@ -34,7 +34,7 @@ export const script = (
     }
   }
 
-  function getSystemTheme(): string {
+  function getSystemTheme() {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
   }
 

--- a/next-themes/src/types.ts
+++ b/next-themes/src/types.ts
@@ -32,6 +32,8 @@ export interface UseThemeProps {
 export type Attribute = DataAttribute | 'class'
 
 export interface ThemeProviderProps extends React.PropsWithChildren {
+  /** Whether to include the script tag in the document head */
+  withScript?: boolean | undefined
   /** List of all available theme names */
   themes?: string[] | undefined
   /** Forced theme name for the current page */

--- a/next-themes/src/types.ts
+++ b/next-themes/src/types.ts
@@ -32,7 +32,7 @@ export interface UseThemeProps {
 export type Attribute = DataAttribute | 'class'
 
 export interface ThemeProviderProps extends React.PropsWithChildren {
-  /** Whether to include the script tag in the document head */
+  /** Whether to include automatically include the script tag in the document */
   withScript?: boolean | undefined
   /** List of all available theme names */
   themes?: string[] | undefined

--- a/next-themes/src/types.ts
+++ b/next-themes/src/types.ts
@@ -56,4 +56,6 @@ export interface ThemeProviderProps extends React.PropsWithChildren {
   nonce?: string
   /** Props to pass the inline script */
   scriptProps?: ScriptProps
+  /** Optional ID */
+  id?: string
 }

--- a/next-themes/src/types.ts
+++ b/next-themes/src/types.ts
@@ -32,7 +32,7 @@ export interface UseThemeProps {
 export type Attribute = DataAttribute | 'class'
 
 export interface ThemeProviderProps extends React.PropsWithChildren {
-  /** Whether to include automatically include the script tag in the document */
+  /** Automatically include the script tag in the document (default is true) */
   withScript?: boolean | undefined
   /** List of all available theme names */
   themes?: string[] | undefined

--- a/next-themes/src/types.ts
+++ b/next-themes/src/types.ts
@@ -56,6 +56,4 @@ export interface ThemeProviderProps extends React.PropsWithChildren {
   nonce?: string
   /** Props to pass the inline script */
   scriptProps?: ScriptProps
-  /** Optional ID */
-  id?: string
 }


### PR DESCRIPTION
# Problem

We've seen a bug in Chrome where (in dark mode) there is a flash of light-themed code.

This appears to be due to how `next-themes` inserts `<ThemeScript />` into the `<body />`

# Solution

This PR:

1. Adds an optional `withScript` prop to `<Theme>`.

  - This allows the user to optionally disable the insertion of `<ThemeScript>` by setting `withScript` to `false`. 
  - `withScript` defaults to `true`, which preserves the default behavior of `next-themes`.

2. Exports `<ThemeScript>`, so it can be manually inserted by the user (i.e. in the `<head>`)

3. Adds an optional string `id` prop that gets added to the script itself

# Example

This is pseudo-code:

```jsx
import { ThemeProvider, ThemeScript } from 'next-themes'

export default function RootLayout({
  children
}): JSX.Element {
  return (
    <html>
      <head>
        <ThemeScript storageKey="my-theme" />
      </head>
      <body>
        <ThemeProvider storageKey="my-theme" withScript={false}>
        {children}
      </body>
    </html>
  )
}
```

Based on internal work from @cramforce:

> This appears to fix a long-standing bug where you get a flash of light-theme in Chrome.
> 
> The primary change in the fork is to allow placing the inline script manually. With the default-usage of next-themes, the script always goes into the body (usually first).
