### PR TITLE
fix: @types/react 17 PropsWithChildren Generic type

### DIFF
--- a/next-themes/src/types.ts
+++ b/next-themes/src/types.ts
@@ -31,7 +31,7 @@ export interface UseThemeProps {
 
 export type Attribute = DataAttribute | 'class'
 
-export interface ThemeProviderProps extends React.PropsWithChildren {
+export interface ThemeProviderProps extends React.PropsWithChildren<unknown> {
   /** List of all available theme names */
   themes?: string[] | undefined
   /** Forced theme name for the current page */


### PR DESCRIPTION
An TypeScript error occurred in React 17.

`Type '{ children: ReactNode; }' has no properties in common with type 'IntrinsicAttributes & ThemeProviderProps'.`

When I checked

[`"@types/react": "18.0.12"`](https://www.npmjs.com/package/@types/react/v/18.0.12?activeTab=code)
- `type PropsWithChildren<P = unknown> = P & { children?: ReactNode | undefined };`

[`"@types/react": "17.0.34"`](https://www.npmjs.com/package/@types/react/v/17.0.34?activeTab=code)
- `type PropsWithChildren<P> = P & { children?: ReactNode | undefined };`

So, to support React 17 version, we need to add Generic. Currently, we have no choice but to use ts-ignore because it always causes a type error.
