### PR TITLE
docs: add instructions to prevent white flash for SPAs

### DIFF
--- a/next-themes/README.md
+++ b/next-themes/README.md
@@ -137,6 +137,27 @@ const ThemeChanger = () => {
 >
 > You should delay rendering any theme toggling UI until mounted on the client. See the [example](#avoid-hydration-mismatch).
 
+### Prevent white flash (SPAs only)
+
+If you use next-themes in Vite, CRA, or any SPA (not Next.js), add this script at the very top of your `public/index.html` `<head>`:
+
+```html
+<script>
+  (function() {
+    try {
+      var theme = localStorage.getItem('theme')
+      if (theme === 'system' || !theme) {
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+        theme = prefersDark ? 'dark' : 'light'
+      }
+      document.documentElement.classList.add(theme)
+    } catch (e) {}
+  })()
+</script>
+```
+
+This ensures the correct theme class is set before your app loads, preventing a white flash.
+
 ## API
 
 Let's dig into the details.


### PR DESCRIPTION
### Summary

This pull request updates the README to help users of next-themes in SPA environments (such as Vite, CRA, or any non-Next.js React app) prevent a white flash (FOUC) on reload. It documents how to add an inline script that applies the correct theme class before the app loads, ensuring a seamless dark/light mode experience.

### Changes

- Added a new section in the README titled **"Prevent white flash (SPAs only)"**.
- Provided an inline script to be placed at the very top of the `<head>` in `public/index.html` for Vite, CRA, and other SPA setups.
- Included an explanation about the necessity of this approach and how it resolves FOUC.

### Reason for Change

While next-themes handles FOUC automatically in Next.js via server-side script injection, SPA frameworks do not include this by default. This omission can cause a white flash before the user's preferred theme is applied, impacting user experience. Documenting this script helps SPA users implement a reliable, recommended fix.

### Additional Notes

This is a documentation-only change. The provided solution is widely used in the SPA community and ensures the correct theme is applied on the first paint, eliminating FOUC. No breaking changes are introduced; this update improves the onboarding and experience for SPA users of next-themes.
