### PR TITLE
feat: support custom theme root element for Shadow DOM isolation

### DIFF
--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -87,7 +87,7 @@ const Theme = ({
     }
 
     enable?.()
-  }, [nonce])
+  }, [nonce, themeRoot])
 
   const setTheme = React.useCallback(value => {
     if (typeof value === 'function') {
@@ -176,7 +176,8 @@ const Theme = ({
           value,
           themes,
           nonce,
-          scriptProps
+          scriptProps,
+          themeRoot
         }}
       />
 

--- a/next-themes/src/script.ts
+++ b/next-themes/src/script.ts
@@ -6,9 +6,10 @@ export const script = (
   themes,
   value,
   enableSystem,
-  enableColorScheme
+  enableColorScheme,
+  element
 ) => {
-  const el = document.documentElement
+  const el = element ?? document.documentElement
   const systemThemes = ['light', 'dark']
 
   function updateDOM(theme: string) {

--- a/next-themes/src/types.ts
+++ b/next-themes/src/types.ts
@@ -54,4 +54,6 @@ export interface ThemeProviderProps extends React.PropsWithChildren<unknown> {
   nonce?: string
   /** Props to pass the inline script */
   scriptProps?: ScriptProps
+  /** Custom root element (e.g. Shadow host) where theme attributes should be applied instead of document.documentElement */
+  themeRoot?: Element
 }


### PR DESCRIPTION
## Add support for custom theme root
This PR adds support for setting a custom root element (`themeRoot`) in the `ThemeProvider`, allowing theme attributes (like data-theme or class) to be scoped to a specific element - particularly useful when rendering components inside Shadow DOM.

## What’s new
`ThemeProvider` now accepts an optional `themeRoot?: Element` prop.

All theme attribute and color-scheme updates are applied to `themeRoot` if provided, falling back to `document.documentElement`.

`disableAnimation` now injects the temporary no-transition `<style>` into `themeRoot.shadowRoot` (if available) instead of `document.head`, preserving encapsulation.

## Why this matters
This enables full theme encapsulation in Web Components and Shadow DOM environments.