### PR TITLE
export ThemeContext

### DIFF
--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -7,7 +7,7 @@ import type { Attribute, ThemeProviderProps, UseThemeProps } from './types'
 const colorSchemes = ['light', 'dark']
 const MEDIA = '(prefers-color-scheme: dark)'
 const isServer = typeof window === 'undefined'
-const ThemeContext = React.createContext<UseThemeProps | undefined>(undefined)
+export const ThemeContext = React.createContext<UseThemeProps | undefined>(undefined)
 const defaultContext: UseThemeProps = { setTheme: _ => { }, themes: [] }
 
 const saveToLS = (storageKey: string, value: string) => {


### PR DESCRIPTION
Use Case:

in a r3f project, i need to [`useContextBridge`](https://drei.docs.pmnd.rs/misc/use-context-bridge) the `ThemeContext` so the `useTheme()` can be consumed into my Scene:

```tsx
// app/App.tsx

'use client'

function App({children}) {
  const ContextBridge = useContextBridge(ThemeContext); // 👈🏻 I need `ThemeContext` HERE
  
  return (
    <ContextBridge>
      <Canvas>
        <Scene />
      </Canvas>
    </ContextBridge>
}

function Scene() {
  const { theme } = useTheme()
  
  return (
    <Box>
      <meshBasicMaterial color={theme === 'light' ? 'red' : 'green'} />
    </Box>
  )
}
```

thus this PR that just `export` ThemeContext