### PR TITLE
fix: handle Node.js 25+ where window is defined in SSR context

### DIFF
--- a/next-themes/src/index.tsx
+++ b/next-themes/src/index.tsx
@@ -6,7 +6,7 @@ import type { Attribute, ThemeProviderProps, UseThemeProps } from './types'
 
 const colorSchemes = ['light', 'dark']
 const MEDIA = '(prefers-color-scheme: dark)'
-const isServer = typeof window === 'undefined'
+const isServer = typeof window === 'undefined' || typeof document === 'undefined'
 const ThemeContext = React.createContext<UseThemeProps | undefined>(undefined)
 const defaultContext: UseThemeProps = { setTheme: _ => { }, themes: [] }
 
@@ -212,7 +212,7 @@ export const ThemeScript = React.memo(
       <script
         {...scriptProps}
         suppressHydrationWarning
-        nonce={typeof window === 'undefined' ? nonce : ''}
+        nonce={isServer ? nonce : ''}
         dangerouslySetInnerHTML={{ __html: `(${script.toString()})(${scriptArgs})` }}
       />
     )


### PR DESCRIPTION
## Bug

Node.js 25 ships an experimental Web Storage API where `window` is aliased to `globalThis`. This means `typeof window === 'undefined'` returns `false` on the server, breaking the SSR guard in `isServer`. The library then tries to call `localStorage.getItem()` in a server context where it's not fully implemented, causing `TypeError: localStorage.getItem is not a function`.

## Fix

Add `typeof document === 'undefined'` to the `isServer` check. `document` is only available in browser environments, not in Node.js even when `window` is polyfilled. Also use `isServer` consistently for the nonce attribute instead of re-checking `typeof window`.

Closes #389