### PR TITLE
fix(script): avoid __name ReferenceError in injected theme script

### DIFF
--- a/next-themes/src/script.ts
+++ b/next-themes/src/script.ts
@@ -11,7 +11,13 @@ export const script = (
   const el = document.documentElement
   const systemThemes = ['light', 'dark']
 
-  function updateDOM(theme: string) {
+  const setColorScheme = (theme: string) => {
+    if (enableColorScheme && systemThemes.includes(theme)) {
+      el.style.colorScheme = theme
+    }
+  }
+
+  const updateDOM = (theme: string) => {
     const attributes = Array.isArray(attribute) ? attribute : [attribute]
 
     attributes.forEach(attr => {
@@ -28,13 +34,7 @@ export const script = (
     setColorScheme(theme)
   }
 
-  function setColorScheme(theme: string) {
-    if (enableColorScheme && systemThemes.includes(theme)) {
-      el.style.colorScheme = theme
-    }
-  }
-
-  function getSystemTheme() {
+  const getSystemTheme = () => {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
   }
 


### PR DESCRIPTION
Fixes #370

When using next-themes with Next.js (Turbopack/SWC), the inline theme script throws Uncaught ReferenceError: __name is not defined.

The SWC compiler re-processes inline script content and injects __name() helper calls for function declarations. These helpers are not available at runtime.

Convert the three inner function declarations in script.ts to const arrow functions. SWC does not annotate arrow functions with __name calls, so the injected script remains self-contained.

setColorScheme is moved before updateDOM since const is not hoisted.